### PR TITLE
Automate start of QEMU with DomA/DomU

### DIFF
--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/doma.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/doma.bbappend
@@ -10,7 +10,7 @@ SRC_URI += "\
 
 FILES:${PN} += " \
     ${libdir}/xen/bin/doma-set-root \
-    ${sysconfdir}/systemd/system/doma.service.d/doma-set-root.conf \
+    ${sysconfdir}/systemd/system/doma-create.service.d/doma-set-root.conf \
 "
 
 do_install:append() {
@@ -21,6 +21,6 @@ do_install:append() {
     # Install doma-set-root script and the drop-in file to run it
     install -d ${D}${libdir}/xen/bin
     install -m 0744 ${WORKDIR}/doma-set-root ${D}${libdir}/xen/bin
-    install -d ${D}${sysconfdir}/systemd/system/doma.service.d
-    install -m 0644 ${WORKDIR}/doma-set-root.conf ${D}${sysconfdir}/systemd/system/doma.service.d
+    install -d ${D}${sysconfdir}/systemd/system/doma-create.service.d
+    install -m 0644 ${WORKDIR}/doma-set-root.conf ${D}${sysconfdir}/systemd/system/doma-create.service.d
 }

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
@@ -19,9 +19,9 @@ do_install:append() {
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'pvcamera', 'true', 'false', d)}; then
         #cat ${WORKDIR}/domu-pvcamera.cfg >> ${CFG_FILE}
-        echo "[Unit]" >> ${D}${systemd_unitdir}/system/domu.service
-        echo "Requires=backend-ready@camerabe.service" >> ${D}${systemd_unitdir}/system/domu.service
-        echo "After=backend-ready@camerabe.service" >> ${D}${systemd_unitdir}/system/domu.service
+        echo "[Unit]" >> ${D}${systemd_unitdir}/system/domu-create.service
+        echo "Requires=backend-ready@camerabe.service" >> ${D}${systemd_unitdir}/system/domu-create.service
+        echo "After=backend-ready@camerabe.service" >> ${D}${systemd_unitdir}/system/domu-create.service
     fi
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'virtio', 'true', 'false', d)}; then
@@ -31,9 +31,9 @@ do_install:append() {
         sed -i 's/root=\/dev\/xvda1/root=\/dev\/vda/' ${CFG_FILE}
 
         # Update GUEST_DEPENDENCIES by adding dependency to the virtio
-        echo "[Unit]" >> ${D}${systemd_unitdir}/system/domu.service
-        echo "Requires=backend-ready@virtio.service" >> ${D}${systemd_unitdir}/system/domu.service
-        echo "After=backend-ready@virtio.service" >> ${D}${systemd_unitdir}/system/domu.service
+        echo "[Unit]" >> ${D}${systemd_unitdir}/system/domu-create.service
+        echo "Requires=backend-ready@virtio.service" >> ${D}${systemd_unitdir}/system/domu-create.service
+        echo "After=backend-ready@virtio.service" >> ${D}${systemd_unitdir}/system/domu-create.service
     fi
 
     # Install domu-set-root script
@@ -41,6 +41,6 @@ do_install:append() {
     install -m 0744 ${WORKDIR}/domu-set-root ${D}${libdir}/xen/bin
 
     # Call domu-set-root script
-    echo "[Service]" >> ${D}${systemd_unitdir}/system/domu.service
-    echo "ExecStartPre=${libdir}/xen/bin/domu-set-root" >> ${D}${systemd_unitdir}/system/domu.service
+    echo "[Service]" >> ${D}${systemd_unitdir}/system/domu-create.service
+    echo "ExecStartPre=${libdir}/xen/bin/domu-set-root" >> ${D}${systemd_unitdir}/system/domu-create.service
 }


### PR DESCRIPTION
In order to reach automated start of the QEMU together with the guest Xen domain, we've replaced:

- 'doma.service' with 'doma-create.service' and 'doma-unpause.service'
- 'domu.service' with 'domu-create.service' and 'domu-unpause.service'

This patch is intended to adapt some of the Yocto recipes to that change.