### PR TITLE
Remove rust from build of DomD & DomU

### DIFF
--- a/meta-xt-domd-gen3/conf/layer.conf
+++ b/meta-xt-domd-gen3/conf/layer.conf
@@ -1,0 +1,12 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have a packages directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "xt-domd-gen3"
+BBFILE_PATTERN_xt-domd-gen3 := "^${LAYERDIR}/"
+BBFILE_PRIORITY_xt-domd-gen3 = "12"
+
+LAYERSERIES_COMPAT_xt-domd-gen3 = "kirkstone"

--- a/meta-xt-domd-gen3/recipes-gnome/gtk+/gtk+3_%.bbappend
+++ b/meta-xt-domd-gen3/recipes-gnome/gtk+/gtk+3_%.bbappend
@@ -1,0 +1,4 @@
+# Avoid installation of the redundant 'adwaita-icon-theme' package.
+# It is causing build of the rust, which we want to avoid, as it takes a lot of time.
+RRECOMMENDS:${PN}:remove = " adwaita-icon-theme-symbolic"
+RRECOMMENDS:${PN}:libc-glibc:remove = " adwaita-icon-theme-symbolic"

--- a/meta-xt-domd-gen3/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/meta-xt-domd-gen3/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,3 @@
+# Removing dependency to the librsvg, as it is using rust.
+# And usage of rust is increasing the build time a lot.
+PACKAGECONFIG:remove = " rsvg"

--- a/meta-xt-domu-gen3/conf/layer.conf
+++ b/meta-xt-domu-gen3/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have a packages directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "xt-domu-gen3"
+BBFILE_PATTERN_xt-domu-gen3 := "^${LAYERDIR}/"
+BBFILE_PRIORITY_xt-domu-gen3 = "12"
+
+LAYERSERIES_COMPAT_xt-domu-gen3 = "kirkstone"
+

--- a/meta-xt-domu-gen3/recipes-gnome/gtk+/gtk+3_%.bbappend
+++ b/meta-xt-domu-gen3/recipes-gnome/gtk+/gtk+3_%.bbappend
@@ -1,0 +1,4 @@
+# Avoid installation of the redundant 'adwaita-icon-theme' package.
+# It is causing build of the rust, which we want to avoid, as it takes a lot of time.
+RRECOMMENDS:${PN}:remove = " adwaita-icon-theme-symbolic"
+RRECOMMENDS:${PN}:libc-glibc:remove = " adwaita-icon-theme-symbolic"

--- a/meta-xt-domu-gen3/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/meta-xt-domu-gen3/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,3 @@
+# Removing dependency to the librsvg, as it is using rust.
+# And usage of rust is increasing the build time a lot.
+PACKAGECONFIG:remove = " rsvg"

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -273,6 +273,7 @@ components:
         - "../meta-xt-rcar/meta-xt-rcar-gles_common"
         - "../meta-xt-prod-devel-rcar/meta-xt-domx-gen3"
         - "../meta-xt-prod-devel-rcar/meta-xt-prod-devel-rcar-driver-domain"
+        - "../meta-xt-prod-devel-rcar/meta-xt-domd-gen3"
       target_images:
         - "tmp/deploy/images/%{MACHINE}/Image"
         - "tmp/deploy/images/%{MACHINE}/xen-%{MACHINE}.uImage"
@@ -327,6 +328,7 @@ components:
         - "../meta-xt-rcar/meta-xt-rcar-fixups"
         - "../meta-xt-rcar/meta-xt-rcar-domu"
         - "../meta-xt-rcar/meta-xt-rcar-gles_common"
+        - "../meta-xt-prod-devel-rcar/meta-xt-domu-gen3"
       build_target: core-image-weston
       target_images:
         - "tmp/deploy/images/%{MACHINE}/Image"


### PR DESCRIPTION
After switching to the Yocto Kirkstone release we've identified several minor dependencies, which include the 'rust' package into the DomD and DomU build. That causes a significant increase in the build-time. Due to the insignificance of the identified dependencies, we've decided to cut them out.

Those dependencies are:
- adwaita-icon-theme, used by the 'gtk+3' package
- librsvg, used by the 'gstreamer1.0-plugins-bad' package

Operability of the fix was confirmed using the bitbake dependency graph.