### PR TITLE
prod-devel-rcar.yaml: Do not install kernel-module-cmemdrv into DomU

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -321,6 +321,8 @@ components:
         # Install kmscube which doesn't require libgbm
         - [IMAGE_INSTALL:append, " kmscube"]
 
+        # Remove unused module which gets broken with Linux v6.4
+        - [IMAGE_INSTALL:remove, " kernel-module-cmemdrv"]
       layers:
         - "../meta-openembedded/meta-oe"
         - "../meta-openembedded/meta-filesystems"


### PR DESCRIPTION
Remove unused module which gets broken with Linux v6.4.0-rc7.

TODO: Consider making DomU generic by not including meta-renesas/meta-rcar-gen3 layer (this requires a bit of rework).